### PR TITLE
Add Inclusion/Exclusion File Filtering via Glob Patterns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpt_copy"
-version = "1.2.0"
+version = "2.0.0"
 description = "A script to concatenate files into a single structured stream."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+
 # Concatenate Files
 
 ## Overview
@@ -9,6 +10,7 @@ This script recursively scans a directory, collects readable files, and concaten
 - Identifies file types based on extensions and formats content accordingly.
 - Excludes binary and ignored files.
 - Outputs structured markdown with file-specific code fences.
+- **New!** Supports filtering files using glob-style include and exclude patterns.
 
 ## Installation
 Ensure you have Python 3 installed. You can install dependencies using:
@@ -28,18 +30,60 @@ python gpt-copy /path/to/directory
 python gpt-copy /path/to/directory -o output.md
 ```
 
-## How It Works
-1. **Collects `.gitignore` rules**
-   - Scans the directory for `.gitignore` files and applies rules accordingly.
-   - Ensures ignored files and directories are skipped.
+### Advanced File Filtering
+You can fine-tune which files are processed using two new options:
 
-2. **Generates a structured file tree**
+- **Include Files (`-i` or `--include`):**
+  Provide one or more glob patterns (with optional brace expansion) to specify files that should be **included**. When specified, only files matching at least one include pattern will be processed.
+
+  **Examples:**
+  - Include all Python files in the `src` folder:
+    ```sh
+    python gpt-copy /path/to/directory -i "src/*.py"
+    ```
+  - Include specific modules using brace expansion:
+    ```sh
+    python gpt-copy /path/to/directory -i "src/{module1,module2}.py"
+    ```
+
+- **Exclude Files (`-e` or `--exclude`):**
+  Provide one or more glob patterns to specify files that should be **excluded**. Exclusion takes precedence over inclusion.
+
+  **Examples:**
+  - Exclude all files in the `tests` folder:
+    ```sh
+    python gpt-copy /path/to/directory -e "tests/*"
+    ```
+  - Exclude a specific file even if it is included by another pattern:
+    ```sh
+    python gpt-copy /path/to/directory -i "src/*.py" -e "src/__init__.py"
+    ```
+
+### Force Mode (`-f` or `--force`)
+The `-f` (or `--force`) option forces the script to ignore `.gitignore` rules and Git-tracked file restrictions. This means the script will process **all** files in the provided directory regardless of any ignore settings.
+
+**Usage Example:**
+```sh
+python gpt-copy /path/to/directory -f
+```
+
+## How It Works
+1. **Collects `.gitignore` Rules**
+   - Scans the directory for `.gitignore` files and applies rules accordingly.
+   - Ensures ignored files and directories are skipped unless `-f` is specified.
+
+2. **Generates a Structured File Tree**
    - Displays a visual representation of the directory structure.
 
-3. **Reads and formats files**
+3. **Reads and Formats Files**
    - Detects file type based on extension.
    - Wraps code files in proper markdown code fences.
    - Skips binary or unrecognized file types.
+
+4. **Applies File Filtering**
+   - **Include Patterns (`-i`):** Only files matching the specified patterns are processed.
+   - **Exclude Patterns (`-e`):** Files matching these patterns are omitted—even if they match an include pattern.
+   - The filtering is applied to file paths relative to the provided root directory.
 
 ## Example Output
 ````

--- a/src/gpt_copy/filter.py
+++ b/src/gpt_copy/filter.py
@@ -1,5 +1,3 @@
-# File: src/gpt_copy/filter.py
-
 import re
 import fnmatch
 

--- a/src/gpt_copy/filter.py
+++ b/src/gpt_copy/filter.py
@@ -7,8 +7,15 @@ import fnmatch
 def expand_braces(pattern: str) -> list[str]:
     """
     Expand a pattern containing simple brace expressions.
+
     For example, "src/{file1,file2}.py" becomes ["src/file1.py", "src/file2.py"].
     This minimal implementation does not support nested braces.
+
+    Args:
+        pattern (str): The pattern containing brace expressions.
+
+    Returns:
+        List[str]: A list of expanded patterns.
     """
     match = re.search(r"\{([^}]+)\}", pattern)
     if not match:
@@ -27,6 +34,13 @@ def matches_any_pattern(rel_path: str, patterns: list[str]) -> bool:
     """
     Return True if the given relative path matches any of the provided glob patterns.
     Each pattern is expanded using expand_braces to support brace expansion.
+
+    Args:
+        rel_path (str): The relative path to check.
+        patterns (List[str]): A list of glob patterns.
+
+    Returns:
+        bool: True if the path matches any pattern, False otherwise.
     """
     for pattern in patterns:
         expanded_patterns = expand_braces(pattern)
@@ -44,6 +58,14 @@ def should_include_file(
 
     - If includes is not empty, the file must match at least one include pattern.
     - If the file matches any exclude pattern, it is excluded.
+
+    Args:
+        rel_path (str): The relative path of the file.
+        includes (List[str]): A list of include glob patterns.
+        excludes (List[str]): A list of exclude glob patterns.
+
+    Returns:
+        bool: True if the file should be included, False otherwise.
     """
     # Exclude takes precedence.
     if excludes and matches_any_pattern(rel_path, excludes):

--- a/src/gpt_copy/filter.py
+++ b/src/gpt_copy/filter.py
@@ -1,0 +1,53 @@
+# File: src/gpt_copy/filter.py
+
+import re
+import fnmatch
+
+
+def expand_braces(pattern: str) -> list[str]:
+    """
+    Expand a pattern containing simple brace expressions.
+    For example, "src/{file1,file2}.py" becomes ["src/file1.py", "src/file2.py"].
+    This minimal implementation does not support nested braces.
+    """
+    match = re.search(r"\{([^}]+)\}", pattern)
+    if not match:
+        return [pattern]
+    pre = pattern[: match.start()]
+    post = pattern[match.end() :]
+    options = match.group(1).split(",")
+    patterns = []
+    for option in options:
+        # Recursively expand in case of multiple braces.
+        patterns.extend(expand_braces(pre + option + post))
+    return patterns
+
+
+def matches_any_pattern(rel_path: str, patterns: list[str]) -> bool:
+    """
+    Return True if the given relative path matches any of the provided glob patterns.
+    Each pattern is expanded using expand_braces to support brace expansion.
+    """
+    for pattern in patterns:
+        expanded_patterns = expand_braces(pattern)
+        for pat in expanded_patterns:
+            if fnmatch.fnmatch(rel_path, pat):
+                return True
+    return False
+
+
+def should_include_file(
+    rel_path: str, includes: list[str], excludes: list[str]
+) -> bool:
+    """
+    Determine if a file should be included based on include and exclude glob patterns.
+
+    - If includes is not empty, the file must match at least one include pattern.
+    - If the file matches any exclude pattern, it is excluded.
+    """
+    # Exclude takes precedence.
+    if excludes and matches_any_pattern(rel_path, excludes):
+        return False
+    if includes:
+        return matches_any_pattern(rel_path, includes)
+    return True

--- a/src/gpt_copy/gpt_copy.py
+++ b/src/gpt_copy/gpt_copy.py
@@ -17,6 +17,13 @@ def is_binary_file(file_path: Path, blocksize: int = 1024) -> bool:
     """
     Determine if a file is binary by reading a block of bytes.
     Checks for null bytes and the ratio of non-text characters.
+
+    Args:
+        file_path (Path): The path to the file.
+        blocksize (int): The number of bytes to read for checking. Default is 1024.
+
+    Returns:
+        bool: True if the file is binary, False otherwise.
     """
     try:
         with file_path.open("rb") as f:
@@ -37,6 +44,12 @@ def is_binary_file(file_path: Path, blocksize: int = 1024) -> bool:
 def infer_language(file_path: Path) -> str:
     """
     Infer a language hint from the file name or extension.
+
+    Args:
+        file_path (Path): The path to the file.
+
+    Returns:
+        str: The inferred language hint.
     """
     if file_path.name.lower() == "dockerfile":
         return "docker"
@@ -54,6 +67,15 @@ def infer_language(file_path: Path) -> str:
 
 
 def find_git_repo(path: Path) -> pygit2.Repository | None:
+    """
+    Find the git repository for the given path.
+
+    Args:
+        path (Path): The path to search for a git repository.
+
+    Returns:
+        Optional[pygit2.Repository]: The found git repository or None if not found.
+    """
     repo_path = pygit2.discover_repository(path.as_posix())
     if repo_path is None:
         return None
@@ -64,12 +86,31 @@ def find_git_repo(path: Path) -> pygit2.Repository | None:
 
 
 def get_tracked_files(repo: pygit2.Repository) -> set[str]:
+    """
+    Get the set of tracked files in the given git repository.
+
+    Args:
+        repo (pygit2.Repository): The git repository.
+
+    Returns:
+        Set[str]: A set of tracked file paths.
+    """
     return {entry.path for entry in repo.index}
 
 
 def get_ignore_settings(
     root_path: Path, force: bool
 ) -> tuple[dict[str, PathSpec], set[str] | None]:
+    """
+    Get the ignore settings based on .gitignore files and git-tracked files.
+
+    Args:
+        root_path (Path): The root path to start searching.
+        force (bool): If True, ignore .gitignore and git-tracked files.
+
+    Returns:
+        Tuple[Dict[str, PathSpec], Optional[Set[str]]]: A tuple containing the gitignore specs and tracked files.
+    """
     if force:
         return {}, None
 
@@ -100,6 +141,15 @@ def get_ignore_settings(
 
 
 def collect_gitignore_specs(root_path: Path) -> dict[str, PathSpec]:
+    """
+    Collect .gitignore specifications for each directory.
+
+    Args:
+        root_path (Path): The root path to start searching.
+
+    Returns:
+        Dict[str, PathSpec]: A dictionary mapping directory paths to PathSpec objects.
+    """
     print("Collecting .gitignore rules per directory...", file=sys.stderr)
     gitignore_specs = {}
 
@@ -132,6 +182,18 @@ def is_ignored(
     root_path: Path,
     tracked_files: set[str] | None = None,
 ) -> bool:
+    """
+    Check if a path is ignored based on gitignore specs and tracked files.
+
+    Args:
+        path (Path): The path to check.
+        gitignore_specs (Dict[str, PathSpec]): The gitignore specifications.
+        root_path (Path): The root path.
+        tracked_files (Optional[Set[str]]): The set of tracked files.
+
+    Returns:
+        bool: True if the path is ignored, False otherwise.
+    """
     rel_path = path.relative_to(root_path).as_posix()
 
     if tracked_files is not None:
@@ -152,6 +214,17 @@ def generate_tree(
     gitignore_specs: dict[str, PathSpec],
     tracked_files: set[str] | None = None,
 ) -> str:
+    """
+    Generate a folder structure tree.
+
+    Args:
+        root_path (Path): The root path to start generating the tree.
+        gitignore_specs (Dict[str, PathSpec]): The gitignore specifications.
+        tracked_files (Optional[Set[str]]): The set of tracked files.
+
+    Returns:
+        str: The generated folder structure tree.
+    """
     print("Generating folder structure tree...", file=sys.stderr)
     tree_lines = [root_path.name or str(root_path)]
 
@@ -188,6 +261,17 @@ def collect_files_content(
     """
     Collect the contents of text files (skipping binary files) based on ignore rules
     and the include/exclude glob patterns.
+
+    Args:
+        root_path (Path): The root path to start collecting files.
+        gitignore_specs (Dict[str, PathSpec]): The gitignore specifications.
+        output_file (Optional[str]): The output file path.
+        tracked_files (Optional[Set[str]]): The set of tracked files.
+        include_patterns (Optional[List[str]]): The list of include glob patterns.
+        exclude_patterns (Optional[List[str]]): The list of exclude glob patterns.
+
+    Returns:
+        Tuple[List[str], List[str]]: A tuple containing the file sections and unrecognized files.
     """
     print("Collecting file contents...", file=sys.stderr)
     file_sections: list[str] = []
@@ -245,7 +329,15 @@ def write_output(
     file_sections: list[str],
     unrecognized_files: list[str],
 ) -> None:
-    """Write collected outputs to the specified output (file or stdout)."""
+    """
+    Write collected outputs to the specified output (file or stdout).
+
+    Args:
+        output (TextIO): The output stream.
+        tree_output (str): The generated folder structure tree.
+        file_sections (List[str]): The collected file sections.
+        unrecognized_files (List[str]): The list of unrecognized files.
+    """
     output.write("# Folder Structure\n\n```\n")
     output.write(tree_output)
     output.write("\n```\n\n")
@@ -306,6 +398,16 @@ def main(
     include_patterns: tuple[str, ...],
     exclude_patterns: tuple[str, ...],
 ) -> None:
+    """
+    Main function to start the script.
+
+    Args:
+        root_path (Path): The root path to start processing.
+        output_file (Optional[str]): The output file path.
+        force (bool): If True, ignore .gitignore and git-tracked files.
+        include_patterns (Tuple[str, ...]): The tuple of include glob patterns.
+        exclude_patterns (Tuple[str, ...]): The tuple of exclude glob patterns.
+    """
     root_path = root_path.resolve()
     print(f"Starting script for directory: {root_path}", file=sys.stderr)
     gitignore_specs, tracked_files = get_ignore_settings(root_path, force)

--- a/src/gpt_copy/gpt_copy.py
+++ b/src/gpt_copy/gpt_copy.py
@@ -10,6 +10,8 @@ from pathspec import PathSpec
 from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 from tqdm import tqdm
 
+from gpt_copy.filter import should_include_file
+
 
 def is_binary_file(file_path: Path, blocksize: int = 1024) -> bool:
     """
@@ -23,14 +25,11 @@ def is_binary_file(file_path: Path, blocksize: int = 1024) -> bool:
                 return True
             if not chunk:
                 return False
-            # Define acceptable text characters (printable ASCII + common whitespace)
             text_chars = bytes(range(32, 127)) + b"\n\r\t\b"
             non_text = sum(1 for byte in chunk if byte not in text_chars)
-            # If more than 30% of the bytes are non-text, consider it binary.
             if (non_text / len(chunk)) > 0.30:
                 return True
     except Exception:
-        # If we cannot read the file, assume it's binary to be safe.
         return True
     return False
 
@@ -38,14 +37,9 @@ def is_binary_file(file_path: Path, blocksize: int = 1024) -> bool:
 def infer_language(file_path: Path) -> str:
     """
     Infer a language hint from the file name or extension.
-    Returns a language string if we can confidently hint one (e.g. for 'Dockerfile'),
-    or an empty string otherwise.
     """
-    # Special-case for Dockerfile (which has no extension)
     if file_path.name.lower() == "dockerfile":
         return "docker"
-    # Optionally, you could add a few common extensions here.
-    # For most files, returning an empty string lets the LLM decide.
     minimal_map = {
         ".py": "python",
         ".js": "javascript",
@@ -60,7 +54,6 @@ def infer_language(file_path: Path) -> str:
 
 
 def find_git_repo(path: Path) -> pygit2.Repository | None:
-    """Search for a Git repository in the given directory or its parents."""
     repo_path = pygit2.discover_repository(path.as_posix())
     if repo_path is None:
         return None
@@ -71,25 +64,12 @@ def find_git_repo(path: Path) -> pygit2.Repository | None:
 
 
 def get_tracked_files(repo: pygit2.Repository) -> set[str]:
-    """Returns a set of all tracked files in the repository."""
     return {entry.path for entry in repo.index}
 
 
 def get_ignore_settings(
     root_path: Path, force: bool
 ) -> tuple[dict[str, PathSpec], set[str] | None]:
-    """
-    Determine the ignore settings based on the presence of a Git repository and the force flag.
-
-    Args:
-        root_path (Path): The directory to scan.
-        force (bool): If True, ignore Git and .gitignore rules.
-
-    Returns:
-        tuple: A tuple (gitignore_specs, tracked_files) where:
-            - gitignore_specs is a dictionary of PathSpec objects (empty when using Git or when force is True).
-            - tracked_files is a set of tracked file paths (or None when not using Git).
-    """
     if force:
         return {}, None
 
@@ -120,7 +100,6 @@ def get_ignore_settings(
 
 
 def collect_gitignore_specs(root_path: Path) -> dict[str, PathSpec]:
-    """Traverse directories and build a dictionary of PathSpec objects for .gitignore rules."""
     print("Collecting .gitignore rules per directory...", file=sys.stderr)
     gitignore_specs = {}
 
@@ -129,13 +108,12 @@ def collect_gitignore_specs(root_path: Path) -> dict[str, PathSpec]:
     ):
         dirpath = Path(dirpath)
         rel_path = dirpath.relative_to(root_path)
-
         gitignore_file = dirpath / ".gitignore"
         if gitignore_file.exists():
             try:
                 with gitignore_file.open("r", encoding="utf-8") as f:
                     patterns = f.read().splitlines()
-                patterns.append(".git/")  # Always ignore .git/
+                patterns.append(".git/")
                 gitignore_specs[rel_path.as_posix()] = PathSpec.from_lines(
                     GitWildMatchPattern, patterns
                 )
@@ -154,15 +132,6 @@ def is_ignored(
     root_path: Path,
     tracked_files: set[str] | None = None,
 ) -> bool:
-    """
-    Check if a file is ignored.
-
-    - When Git-tracking info is available, that branch is used.
-    - Otherwise, .gitignore rules are applied.
-
-    (For directories, a trailing "/" is added so that patterns ending with "/"
-    match as expected.)
-    """
     rel_path = path.relative_to(root_path).as_posix()
 
     if tracked_files is not None:
@@ -170,7 +139,6 @@ def is_ignored(
             return not any(f.startswith(rel_path + "/") for f in tracked_files)
         return rel_path not in tracked_files
 
-    # When using .gitignore rules, for directories add a trailing slash.
     rel_path_for_match = rel_path + "/" if path.is_dir() else rel_path
     for spec in gitignore_specs.values():
         if spec.match_file(rel_path_for_match):
@@ -184,7 +152,6 @@ def generate_tree(
     gitignore_specs: dict[str, PathSpec],
     tracked_files: set[str] | None = None,
 ) -> str:
-    """Generate a textual tree representation of the folder structure."""
     print("Generating folder structure tree...", file=sys.stderr)
     tree_lines = [root_path.name or str(root_path)]
 
@@ -214,22 +181,21 @@ def collect_files_content(
     root_path: Path,
     gitignore_specs: dict[str, PathSpec],
     output_file: str | None,
-    tracked_files: set[str] | None = None,
+    tracked_files: set[str] | None,
+    include_patterns: list[str] | None = None,
+    exclude_patterns: list[str] | None = None,
 ) -> tuple[list[str], list[str]]:
     """
-    Collect the contents of text files (skipping binary files) based on ignore rules.
-
-    Every file that is not ignored and not binary is read and included in the output.
-    If a language hint can be inferred (via infer_language), it is used; otherwise,
-    the file is wrapped in a code fence with no language specifier.
-
-    Returns:
-      - A list of markdown-formatted sections for each file.
-      - A list of file paths (as strings) for which the file was skipped because it was binary.
+    Collect the contents of text files (skipping binary files) based on ignore rules
+    and the include/exclude glob patterns.
     """
     print("Collecting file contents...", file=sys.stderr)
     file_sections: list[str] = []
     unrecognized_files: list[str] = []
+
+    # Ensure include/exclude are lists.
+    include_patterns = include_patterns or []
+    exclude_patterns = exclude_patterns or []
 
     for dirpath, _, filenames in os.walk(root_path):
         for filename in filenames:
@@ -238,15 +204,18 @@ def collect_files_content(
             if is_ignored(full_file_path, gitignore_specs, root_path, tracked_files):
                 continue
 
-            # Avoid reprocessing the output file if it's in the same directory.
+            # Avoid reprocessing the output file.
             if output_file and (full_file_path.name == Path(output_file).name):
                 continue
 
-            rel_path = full_file_path.relative_to(root_path)
+            rel_path = full_file_path.relative_to(root_path).as_posix()
 
-            # Skip binary files.
+            # Apply include/exclude filters.
+            if not should_include_file(rel_path, include_patterns, exclude_patterns):
+                continue
+
             if is_binary_file(full_file_path):
-                unrecognized_files.append(rel_path.as_posix())
+                unrecognized_files.append(rel_path)
                 continue
 
             try:
@@ -261,10 +230,9 @@ def collect_files_content(
 
             language = infer_language(full_file_path)
             file_header = f"## File: `{rel_path}`\n*(Relative Path: `{rel_path}`)*"
-            if language:
-                fenced_content = f"```{language}\n{content}\n```"
-            else:
-                fenced_content = f"```\n{content}\n```"
+            fenced_content = (
+                f"```{language}\n{content}\n```" if language else f"```\n{content}\n```"
+            )
             section = f"{file_header}\n\n{fenced_content}\n\n---\n"
             file_sections.append(section)
 
@@ -317,18 +285,38 @@ def write_output(
     is_flag=True,
     help="Force generation: ignore .gitignore and Git-tracked files",
 )
-def main(root_path: Path, output_file: str | None, force: bool) -> None:
-    # Ensure we have an absolute path so that relative comparisons work correctly.
+@click.option(
+    "-i",
+    "--include",
+    "include_patterns",
+    multiple=True,
+    help="Glob pattern(s) to include files (e.g., 'src/*.py', 'src/{module1,module2}.py')",
+)
+@click.option(
+    "-e",
+    "--exclude",
+    "exclude_patterns",
+    multiple=True,
+    help="Glob pattern(s) to exclude files (e.g., 'src/tests/*')",
+)
+def main(
+    root_path: Path,
+    output_file: str | None,
+    force: bool,
+    include_patterns: tuple[str, ...],
+    exclude_patterns: tuple[str, ...],
+) -> None:
     root_path = root_path.resolve()
-
     print(f"Starting script for directory: {root_path}", file=sys.stderr)
-
-    # Determine ignore settings based on the force flag and repository presence.
     gitignore_specs, tracked_files = get_ignore_settings(root_path, force)
-
     tree_output = generate_tree(root_path, gitignore_specs, tracked_files)
     file_sections, unrecognized_files = collect_files_content(
-        root_path, gitignore_specs, output_file, tracked_files
+        root_path,
+        gitignore_specs,
+        output_file,
+        tracked_files,
+        include_patterns=list(include_patterns),
+        exclude_patterns=list(exclude_patterns),
     )
 
     if output_file:

--- a/tests/test_file_filtering.py
+++ b/tests/test_file_filtering.py
@@ -1,0 +1,35 @@
+# File: tests/test_file_filtering.py
+
+from gpt_copy.filter import expand_braces, matches_any_pattern, should_include_file
+
+
+def test_expand_braces_no_braces():
+    pattern = "src/*.py"
+    assert expand_braces(pattern) == [pattern]
+
+
+def test_expand_braces_simple():
+    pattern = "src/{file1,file2}.py"
+    expanded = expand_braces(pattern)
+    assert "src/file1.py" in expanded
+    assert "src/file2.py" in expanded
+    assert len(expanded) == 2
+
+
+def test_matches_any_pattern():
+    patterns = ["src/*.py", "docs/*.md"]
+    assert matches_any_pattern("src/main.py", patterns) is True
+    assert matches_any_pattern("docs/readme.md", patterns) is True
+    assert matches_any_pattern("src/main.txt", patterns) is False
+
+
+def test_should_include_file_with_includes_excludes():
+    includes = ["src/*.py"]
+    excludes = ["src/__init__.py"]
+    # Should include: matches include and is not excluded.
+    assert should_include_file("src/main.py", includes, excludes) is True
+    # Should exclude: even though it matches include, it is explicitly excluded.
+    assert should_include_file("src/__init__.py", includes, excludes) is False
+    # With no includes, a file is included unless it is excluded.
+    assert should_include_file("docs/readme.md", [], ["docs/*.md"]) is False
+    assert should_include_file("docs/readme.md", [], []) is True

--- a/tests/test_manual_gitignore.py
+++ b/tests/test_manual_gitignore.py
@@ -98,7 +98,9 @@ def test_is_ignored(temp_directory: Path):
 def test_collect_files_content(temp_directory: Path):
     """Ensure files are correctly collected and recognized."""
     gitignore_specs = collect_gitignore_specs(temp_directory)
-    files, unrecognized = collect_files_content(temp_directory, gitignore_specs, None)
+    files, unrecognized = collect_files_content(
+        temp_directory, gitignore_specs, None, None
+    )
 
     assert len(files) > 0
     # Now, since we use infer_language, recognized files (like file.py) will be wrapped with a language hint.


### PR DESCRIPTION
## Summary

This PR introduces two new, repeatable CLI options to allow users to filter files by inclusion and exclusion patterns. The options accept glob-style patterns (with optional brace expansion) so that users can intuitively select which files should be processed without having to provide full, exact paths. This feature provides more granular control over file selection and helps avoid redundant specification of similar paths.

## Proposed Changes

1. **New CLI Options:**
   - **`--include` (`-i`):**  
     - Accepts one or more glob patterns.
     - When provided, only files whose relative paths match at least one include pattern will be processed.
   - **`--exclude` (`-e`):**  
     - Accepts one or more glob patterns.
     - Any file matching an exclude pattern is omitted—even if it matches an include pattern.

2. **Pattern Matching:**
   - Use Python’s standard glob matching (or extend the use of the `pathspec` library) to support both wildcards (e.g., `"src/*.py"`) and brace expansion (e.g., `"src/{module1,module2}.py"`).
   - Patterns will be applied against the file paths relative to the user-specified root directory.

3. **Processing Order:**
   - **Step 1:** If include patterns are provided, filter the list of candidate files to those that match at least one of the patterns.
   - **Step 2:** Apply exclusion patterns to remove any files that match.
   - **Note:** Exclusion patterns take precedence over inclusion patterns.

4. **User Feedback (Optional):**
   - When running in a verbose or “dry-run” mode, print the list of files matching the include and exclude filters so users can verify the selection.

## Rationale

- **Intuitive Syntax:**  
  Glob patterns (e.g., `"src/*.py"`) are widely recognized and understood by developers. This avoids the need for users to specify lengthy or exact file paths.

- **Flexibility:**  
  The ability to combine multiple patterns lets users select broad classes of files (e.g., all Python files) and then exclude specific ones (e.g., `src/__init__.py`), all in one command.

- **Consistency:**  
  The new options align with the `.gitignore` syntax already in use, so users familiar with that system will quickly understand how to use the new parameters.

- **Implementation Ease:**  
  Leveraging existing libraries (like `pathspec` or Python’s `fnmatch`) minimizes the development effort while providing robust pattern matching.

## Examples

- **Include all Python files in the `src` directory:**
  ```bash
  python gpt-copy /project/root --include "src/*.py"
  ```

- **Include multiple specific modules (using brace expansion):**
  ```bash
  python gpt-copy /project/root --include "src/{module1,module2}.py"
  ```

- **Include all `.py` files but exclude initialization files:**
  ```bash
  python gpt-copy /project/root --include "src/*.py" --exclude "src/__init__.py"
  ```

- **Exclude test files across the project:**
  ```bash
  python gpt-copy /project/root --exclude "src/tests/*"
  ```

## Acceptance Criteria

1. **CLI Interface:**
   - The CLI must accept `--include` (alias `-i`) and `--exclude` (alias `-e`) as repeatable options.
   - The options accept one or more glob patterns.

2. **File Selection:**
   - When `--include` is used, only files matching at least one include pattern are processed.
   - When `--exclude` is used, any file matching an exclude pattern is omitted—even if it would otherwise be included.
   - Exclusion patterns must override inclusion patterns.

3. **Pattern Matching:**
   - The matching should support standard glob wildcards (e.g., `*`, `?`) and brace expansion (e.g., `{file1,file2}`).
   - Patterns are applied to file paths relative to the root provided by the user.

4. **Testing & Documentation:**
   - Unit tests must cover:
     - Matching files using include patterns.
     - Excluding files with exclude patterns.
     - Combined behavior when both options are provided.
   - Documentation (README and help text in the CLI) must explain the syntax and examples of usage.
   - A “dry-run” or verbose mode (if available) should output the matched file list for user verification.

5. **Backward Compatibility:**
   - The new options must be optional.
   - Existing behavior (without specifying any include/exclude patterns) should remain unchanged.
