### PR TITLE
feat: add line numbering option to file output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpt_copy"
-version = "2.1.0"
+version = "2.2.0"
 description = "A script to concatenate files into a single structured stream."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
- Introduce the `add_line_numbers` helper function to number each line with zero-padding.
- Update `collect_files_content` to apply line numbering when the -n/--number flag is enabled.
- Add the new CLI option (-n/--number) in the main command.
- Bump project version to 2.2.0.

fix #15 